### PR TITLE
Kansellere bostedsadresse-hendelser med endringstype 'OPPHOERT'

### DIFF
--- a/src/main/kotlin/no/nav/bidrag/person/hendelse/database/Databasetjeneste.kt
+++ b/src/main/kotlin/no/nav/bidrag/person/hendelse/database/Databasetjeneste.kt
@@ -65,6 +65,11 @@ open class Databasetjeneste(open val hendelsemottakDao: HendelsemottakDao) {
             status = Status.MOTTATT
         }
 
+        // Kansellerer hendelser om opphør av bostedsadresse. Endring av eksisterende bostedsadresse fører til utsending av to hendelser. Opprett for ny adresse og opphør for gammel.
+        if (Livshendelse.Opplysningstype.BOSTEDSADRESSE_V1 == livshendelse.opplysningstype && Livshendelse.Endringstype.OPPHOERT == livshendelse.endringstype) {
+            status = Status.KANSELLERT
+        }
+
         return hendelsemottakDao.save(
             Hendelsemottak(
                 livshendelse.hendelseid,
@@ -81,7 +86,8 @@ open class Databasetjeneste(open val hendelsemottakDao: HendelsemottakDao) {
     }
 
     private fun kansellereTidligereHendelse(livshendelse: Livshendelse): Status {
-        var tidligereHendelseMedStatusMottatt = livshendelse.tidligereHendelseid?.let { hendelsemottakDao.findByHendelseidAndStatus(it, Status.MOTTATT) }
+        var tidligereHendelseMedStatusMottatt =
+            livshendelse.tidligereHendelseid?.let { hendelsemottakDao.findByHendelseidAndStatus(it, Status.MOTTATT) }
         tidligereHendelseMedStatusMottatt?.status = Status.KANSELLERT
         tidligereHendelseMedStatusMottatt?.statustidspunkt = LocalDateTime.now()
 

--- a/src/test/kotlin/no/nav/bidrag/person/hendelse/database/DatabasetjenesteTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/person/hendelse/database/DatabasetjenesteTest.kt
@@ -67,6 +67,23 @@ open class DatabasetjenesteTest {
     }
 
     @Test
+    fun `skal kansellere opphør av bostedsadresse`() {
+
+        // gitt
+        var hendelseid = "c096ca6f-9801-4543-9a44-116f4ed806ce"
+        var hendelse =
+            Livshendelse(hendelseid, Opplysningstype.BOSTEDSADRESSE_V1, Endringstype.OPPHOERT, personidenter)
+
+        // hvis
+        var lagretHendelse = databasetjeneste.lagreHendelse(hendelse)
+
+        // så
+        assertSoftly {
+            lagretHendelse.status shouldBe Status.KANSELLERT
+        }
+    }
+
+    @Test
     @Transactional
     fun tidligereHendelseidFinnesIkkeIDatabasen() {
 


### PR DESCRIPTION
Endring av eksisterende bostedsadresse fører til at det sendes ut to livshendelser. Én hendelse for opprettelse den nye adressen, og én hendelse for opphør av den gamle.